### PR TITLE
Delete leftover conflict messages

### DIFF
--- a/daviolinplot/daviolinplot.m
+++ b/daviolinplot/daviolinplot.m
@@ -182,11 +182,8 @@ addParameter(p, 'bins', 10);
 addParameter(p, 'colors', get(gca,'colororder'));
 addParameter(p, 'violinalpha', 1);
 addParameter(p, 'violinwidth', 1);
-<<<<<<< HEAD
 addParameter(p, 'violinmin',[]);
 addParameter(p, 'violinmax',[]);
-=======
->>>>>>> 87178648104a9d2e1b75fee13c302ddb3d365bee
 addParameter(p, 'smoothing','default');
 addParameter(p, 'box', 2);
 addParameter(p, 'boxcolors', 'k'); 


### PR DESCRIPTION
Thank you for developing such a useful function. I noticed that some lines left from manually resolving merge conflicts were causing the function to fail, so I removed them.